### PR TITLE
fix: fix namespace without separator in some cases

### DIFF
--- a/lib/namespaces.php
+++ b/lib/namespaces.php
@@ -62,7 +62,7 @@ function get_autoload_meta($file, $composer)
                 if (0 === strpos($file, rtrim($path, '/')) && strlen($path) > $autoloadLen) {
                     $autoloadMeta = array(
                         'type' => $autoloadStd,
-                        'path' => $path,
+                        'path' => rtrim($path, '/'),
                         'prefix' => rtrim($prefix, '\\')
                     );
 


### PR DESCRIPTION
When using the `PhpNamespaceGet()` method, it returned `AppModel` instead of `App\Model`